### PR TITLE
Fix Makefle to work in all OSs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,11 @@ REMOVE = rm -f
 REMOVEDIR = rm -rf
 COPY = cp
 WINSHELL = cmd
-
+ifeq ($(OS),Windows_NT)
+DEVNULL = NUL
+else
+DEVNULL = /dev/null
+endif
 
 # Define Messages
 # English
@@ -452,11 +456,11 @@ ELFSIZE = $(SIZE) --mcu=$(MCU) --format=avr $(TARGET).elf
 
 sizebefore:
 	@if test -f $(TARGET).elf; then echo; echo $(MSG_SIZE_BEFORE); $(ELFSIZE); \
-	2>/dev/null; echo; fi
+	2>$(DEVNULL); echo; fi
 
 sizeafter:
 	@if test -f $(TARGET).elf; then echo; echo $(MSG_SIZE_AFTER); $(ELFSIZE); \
-	2>/dev/null; echo; fi
+	2>$(DEVNULL); echo; fi
 
 # Display compiler version information.
 gccversion :
@@ -636,11 +640,11 @@ clean_list :
 
 
 # Create object files directory
-$(shell mkdir $(OBJDIR) 2>/NUL)
+$(shell mkdir $(OBJDIR) 2>$(DEVNULL))
 
 
 # Include the dependency files.
--include $(shell mkdir .dep 2>NUL) $(wildcard .dep/*)
+-include $(shell mkdir .dep 2>$(DEVNULL)) $(wildcard .dep/*)
 
 
 # Listing of phony targets.

--- a/Makefile
+++ b/Makefile
@@ -506,6 +506,7 @@ endif
 	@echo break main >> $(GDBINIT_FILE)
 
 debug: gdb-config $(TARGET).elf
+ifeq ($(OS),Windows_NT)
 ifeq ($(DEBUG_BACKEND), avarice)
 	@echo Starting AVaRICE - Press enter when "waiting to connect" message displays.
 	@$(WINSHELL) /c start avarice --jtag $(JTAG_DEV) --erase --program --file \
@@ -518,6 +519,19 @@ else
 endif
 	@$(WINSHELL) /c start avr-$(DEBUG_UI) --command=$(GDBINIT_FILE)
 
+else
+ifeq ($(DEBUG_BACKEND), avarice)
+	@echo Starting AVaRICE - Press enter when "waiting to connect" message displays.
+	@avarice --jtag $(JTAG_DEV) --erase --program --file \
+	$(TARGET).elf $(DEBUG_HOST):$(DEBUG_PORT)
+	@bash -c 'read -n1 -p "Hit enter after \"waiting to connect\" message: " key'
+
+else
+	@simulavr --gdbserver --device $(MCU) --clock-freq \
+	$(DEBUG_MFREQ) --port $(DEBUG_PORT)
+endif
+	@avr-$(DEBUG_UI) --command=$(GDBINIT_FILE)
+endif
 
 
 


### PR DESCRIPTION
Although original WinAVR Makefile was written for UNIX platforms in mind, nanoBoot modification was written for Windows NT in mind.  This mixed mind created Malefile which have problem on both OSs.

First patch addresses the NUL /dev/null differences.  The second patch addresses the cmd.exe bash  differences.

Unlike previously proposed unadoptted patch jist for UNIX platforms (already dropped), this one should cause no harm to Windows users while we can build cleanly on UNIX platforms.