### PR TITLE
Make this compatible with any CKDIV8 values while keeping this in 512 Bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ The name *nanoBoot* comes from the fact that the compiled source fits in the sma
 
 It's very likely that a few sections can be rewritten to make it even smaller, and the ultimate goal is to support EEPROM programming as well, although that would require changes to the host code.
 
-The current version (commit #[5401f92](https://github.com/volium/nanoBoot/commit/5f84c0c44d78e907de869176c576855c8ba7a2f2)) is supported as-is in the 'hid_bootloader_loader.py' script that ships with [LUFA-151115](https://github.com/abcminiuser/lufa/releases/tag/LUFA-151115), and is exactly 508 bytes long.
+<!--The current version (commit #[5401f92](https://github.com/volium/nanoBoot/commit/5f84c0c44d78e907de869176c576855c8ba7a2f2)) is supported as-is in the 'hid_bootloader_loader.py' script that ships with [LUFA-151115](https://github.com/abcminiuser/lufa/releases/tag/LUFA-151115), and is exactly 508 bytes long.-->
+
+The current version (2020-04-03) is supported as-is in the 'hid_bootloader_loader.py' script that ships with [LUFA-151115](https://github.com/abcminiuser/lufa/releases/tag/LUFA-151115), and is exactly 512 bytes long.
+
+## HW assumptions:
+
+* CLK is 16 MHz Crystal and fuses are setup correctly to support it:
+    * Select Clock Source (CKSEL3:CKSEL0) fuses are set to Extenal Crystal, CKSEL=1111 SUT=11
+    * Divide clock by 8 fuse (CKDIV8) can be any value.
+* Bootloader starts on reset; Hardware Boot Enable fuse is configured, HWBE=0
+* Boot Flash Size is set correctly to 256 words (512 bytes), StartAddress=0x3F00, BOOTSZ=11
+* Device signature = 0x1E9587
+
+* Fuse Settings:
+    * lfuse memory = 0xFF or 0x7F (CKDIV8=1 or 0, 16CK+65ms)
+    * hfuse memory = 0xD6 (EESAVE=0, BOOTRST=0)
+    * efuse memory = 0xC7 (=0xF7, No BOD)
+
+* Alternatively BOD can be used to ease CKSEL-SUT setting requirements to
+  allow teensy like FUSE setting
+    * lfuse memory = 0x5F (CKDIV8=0, 16CK + 0ms)
+    * hfuse memory = 0xDF (EESAVE=1, BOOTRST=1)
+    * efuse memory = 0xF4 (BOD=2.4V)
 
 The documentation is part of the source code itself, and even though some people may find it extremely verbose, I think that's better than lack of documentation; after all, assembly can be hard to read sometimes... ohhh yes, in case that was not expected, this is all written in pure GAS (GNU Assembly), compiled using the [Atmel AVR 8-bit Toolchain](http://www.atmel.com/tools/atmelavrtoolchainforwindows.aspx).

--- a/nanoBoot.S
+++ b/nanoBoot.S
@@ -456,8 +456,9 @@ wait_pll_lock:
 ; =================================================================
 
 main_loop:
-      brtc        exit_bootloader               ; check BootLoaderActive flag, branch if cleared
-      rjmp        main_loop                     ; while the T flag in SREG is set, keep looping
+;      brtc        exit_bootloader               ; check BootLoaderActive flag, branch if cleared
+;      rjmp        main_loop                     ; while the T flag in SREG is set, keep looping
+      brts        main_loop                     ; check BootLoaderActive flag, loop if set
 
 
 exit_bootloader:
@@ -606,7 +607,8 @@ HOST_TO_DEVICE:
       cpi         reg_bmRequestType, ((1 << 5) | (1 << 0))  ; Compare the masked value in r16 with the value that defines the request type and recipient we care about HID_SET_REPORT (REQTYPE_CLASS | REQREC_INTERFACE)
       breq        HANDLE_USB_CLAS_INTERFACE                 ; jump to END_USB_Device_ControlRequest
 
-      rjmp        UNHANDLED_HOST_TO_DEVICE
+      ;rjmp        UNHANDLED_HOST_TO_DEVICE
+      rjmp        UNHANDLED_SETUP_REQUEST
 
 HANDLE_USB_STANDARD_DEVICE:
 
@@ -616,14 +618,15 @@ HANDLE_USB_STANDARD_DEVICE:
       cpi         reg_bRequest, 0x09            ; Compare bRequest with value 0x09 (REQ_SetConfiguration)
       breq        SET_CONFIGURATION             ; jump to SET_CONFIGURATION
 
-      rjmp        UNHANDLED_HOST_TO_DEVICE
+;      rjmp        UNHANDLED_HOST_TO_DEVICE
+      rjmp        UNHANDLED_SETUP_REQUEST
 
 HANDLE_USB_CLAS_INTERFACE:
       cpi         reg_bRequest, 0x09            ; Compare bRequest with value 0x05 (HID_REQ_SetReport)
       breq        SET_HID_REPORT                ; jump to END_USB_Device_ControlRequest
 
-UNHANDLED_HOST_TO_DEVICE:
-      rjmp        UNHANDLED_SETUP_REQUEST       ; If reg_bmRequestType is not 0x00 or bRequest is not 0x05 or 0x09, we don't handle those cases, so jump to UNHANDLED_SETUP_REQUEST
+;UNHANDLED_HOST_TO_DEVICE:
+;      rjmp        UNHANDLED_SETUP_REQUEST       ; If reg_bmRequestType is not 0x00 or bRequest is not 0x05 or 0x09, we don't handle those cases, so jump to UNHANDLED_SETUP_REQUEST
 
 
 SET_ADDRESS:
@@ -860,8 +863,10 @@ send_packet_done:
 wait_finish_transfer:
       ldd         r17, Y+oUEINTX                ; Load r17 with the most current value in the USB Endpoint Interrupt Register (UEINTX);
       sbrs        r17, RXOUTI                   ; Skip the next instruction if the Received OUT Data Interrupt Flag (RXOUTI) is set (there's already an OUT packet from the host), go to acknowledge_rxouti
-      sbrc        r17, RXSTPI                   ; Skip the next instruction if the Received SETUP Interrupt Flag (RXSTPI) is not set; no need to abort, we haven't received another SETUP packet, we can keep looping
-      rjmp        acknowledge_rxouti            ; Jump if either RXOUTI or RXSTPI are set
+;      sbrc        r17, RXSTPI                   ; Skip the next instruction if the Received SETUP Interrupt Flag (RXSTPI) is not set; no need to abort, we haven't received another SETUP packet, we can keep looping
+;      rjmp        acknowledge_rxouti            ; Jump if either RXOUTI or RXSTPI are set
+;      rjmp        wait_finish_transfer          ; Loop back to finish_transfer until either Received OUT Data Interrupt Flag (RXOUTI) or Received SETUP Interrupt Flag (RXSTPI) is set
+      sbrs        r17, RXSTPI                   ; Skip the next instruction if the Received SETUP Interrupt Flag (RXSTPI) is set; no need to abort, we haven't received another SETUP packet, we can keep looping
       rjmp        wait_finish_transfer          ; Loop back to finish_transfer until either Received OUT Data Interrupt Flag (RXOUTI) or Received SETUP Interrupt Flag (RXSTPI) is set
 
 acknowledge_rxouti:

--- a/nanoBoot.S
+++ b/nanoBoot.S
@@ -30,15 +30,21 @@
 ; HW assumptions:
 ; CLK is 16 MHz Crystal and fuses are setup correctly to support it:
 ;     Select Clock Source (CKSEL3:CKSEL0) fuses are set to Extenal Crystal, CKSEL=1111 SUT=11
-;     Divide clock by 8 fuse (CKDIV8) is NOT set, CKDIV8=0
+;     Divide clock by 8 fuse (CKDIV8) can be any value.
 ; Bootloader starts on reset; Hardware Boot Enable fuse is configured, HWBE=0
 ; Boot Flash Size is set correctly to 256 words (512 bytes), StartAddress=0x3F00, BOOTSZ=11
 
 ; Fuse Settings:
 ; Device signature = 0x1E9587
-; lfuse memory = 0xFF
-; hfuse memory = 0xD6
-; efuse memory = 0xC7
+; lfuse memory = 0xFF or 0x7F (CKDIV8=1 or 0, 16CK+65ms)
+; hfuse memory = 0xD6 (EESAVE=0, BOOTRST=0)
+; efuse memory = 0xC7 (=0xF7, No BOD)
+
+; Alternatively BOD can be used to ease CKSEL-SUT setting requirements to
+; allow teensy like FUSE setting
+; lfuse memory = 0x5F (CKDIV8=0, 16CK + 0ms)
+; hfuse memory = 0xDF (EESAVE=1, BOOTRST=1)
+; efuse memory = 0xF4 (BOD=2.4V)
 
 ; SW assumptions:
 ; All Endpoints are being configured sequentially in ascending order,
@@ -324,9 +330,9 @@ run_bootloader:
       ; sbrs        r17, EXTON                    ; Skip the next instruction if the External Clock On bit (EXTON) is set (External Clk is running); basically, move on
       ; rjmp        1b                            ; Jump to 1Backwards if the External Clock On bit (EXTON) is not set (External Clk not running)
 
-      ; ldi         r17, _BV(CLKPCE)              ; Load r17 with the value needed to "unlock" the prescaler of the Clock; Clock Prescaler Change Enable bit (CLKPCE) set to one, all other bits set to zero.
-      ; sts         CLKPR, r17                    ; Store r17 to the Clock Prescaler Register (CLKPR)
-      ; sts         CLKPR, rZERO                  ; Store rZERO to the Clock Prescaler Register (CLKPR), setting CLKPS3, CLKPS2, CLKPS1 and CLKPS0 to zero (Clock Division Factor = 1; System Clock is 16 MHz)
+      ldi         r17, _BV(CLKPCE)              ; Load r17 with the value needed to "unlock" the prescaler of the Clock; Clock Prescaler Change Enable bit (CLKPCE) set to one, all other bits set to zero.
+      sts         CLKPR, r17                    ; Store r17 to the Clock Prescaler Register (CLKPR)
+      sts         CLKPR, rZERO                  ; Store rZERO to the Clock Prescaler Register (CLKPR), setting CLKPS3, CLKPS2, CLKPS1 and CLKPS0 to zero (Clock Division Factor = 1; System Clock is 16 MHz)
 
 ; =================================================================
 ; = Basic device setup is NOW COMPLETE!!


### PR DESCRIPTION
I had a time to read nicely commented assembler source and realized we can squeeze 6
more bytes and insert 10 bytes to support CKDIV8 fuse setting un 512 Bytes bootloader.  (Many ATmega32u4 boards are sold with this fuse set as default.)

This compiles fine.  I didn't have time to test this yet.

Please have a look when you find time.  I will test this soon.

Osamu